### PR TITLE
Only load default email and password  in development moode on login s…

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -51,8 +51,9 @@ const Login = () => {
     resolver: yupResolver(loginSchema),
     mode: 'onBlur',
     defaultValues: {
-      identifier: 'anothertest@gmail.com',
-      password: '1234abcdA@',
+      identifier:
+        process.env.NODE_ENV === 'development' ? 'anothertest@gmail.com' : '',
+      password: process.env.NODE_ENV === 'development' ? '1234abcdA@' : '',
     },
   })
 


### PR DESCRIPTION
…creen
This pull request makes a small change to the default values used in the login form. Now, the form will pre-fill the `identifier` and `password` fields with test credentials only when running in development mode, and leave them blank in other environments.

* Updated the `defaultValues` in the login form to conditionally use test credentials based on `NODE_ENV`, improving security and developer experience.